### PR TITLE
check the content_type if the incoming file is gzipped.

### DIFF
--- a/m3u-epg-editor-py3.py
+++ b/m3u-epg-editor-py3.py
@@ -683,7 +683,8 @@ def save_new_m3u(args, m3u_entries):
 def load_epg(args):
     epg_response = get_epg(args.epgurl)
     if epg_response.status_code == 200:
-        is_gzipped = args.epgurl.lower().endswith(".gz")
+        if args.epgurl.lower().endswith(".gz") or epg_response.headers['Content-Type'] == "application/x-gzip":
+            is_gzipped = True
         is_http_response = args.epgurl.lower().startswith("http")
         epg_filename = save_original_epg(is_gzipped, is_http_response, args.outdirectory, epg_response)
         if is_http_response:


### PR DESCRIPTION
small fix to work with xtream-editor.com

The epg url is https://xtream-editor.com/en/get/epg/<id> and is compressed so the filename check does not work.